### PR TITLE
`crystal tool format` with Crystal 1.15.0-dev

### DIFF
--- a/spec/catalog/duplication_spec.cr
+++ b/spec/catalog/duplication_spec.cr
@@ -2,7 +2,7 @@ require "spec"
 require "../../src/catalog"
 require "file_utils"
 
-private def with_tempdir(name)
+private def with_tempdir(name, &)
   path = File.join(Dir.tempdir, name)
   FileUtils.mkdir_p(path)
 

--- a/spec/catalog_spec.cr
+++ b/spec/catalog_spec.cr
@@ -2,7 +2,7 @@ require "spec"
 require "../src/catalog"
 require "file_utils"
 
-private def with_tempdir(name)
+private def with_tempdir(name, &)
   path = File.join(Dir.tempdir, name)
   FileUtils.mkdir_p(path)
 

--- a/spec/support/db.cr
+++ b/spec/support/db.cr
@@ -3,7 +3,7 @@ require "../../src/db"
 
 ShardsDB.database_url = ENV["TEST_DATABASE_URL"]
 
-def transaction
+def transaction(&)
   ShardsDB.transaction do |db, transaction|
     db.connection.on_notice do |notice|
       puts

--- a/spec/support/tempdir.cr
+++ b/spec/support/tempdir.cr
@@ -1,6 +1,6 @@
 require "file_utils"
 
-def with_tempdir(name)
+def with_tempdir(name, &)
   path = File.join(Dir.tempdir, name)
   FileUtils.mkdir_p(path)
 

--- a/src/catalog.cr
+++ b/src/catalog.cr
@@ -92,7 +92,7 @@ class Catalog
     end
   end
 
-  def each_category
+  def each_category(&)
     local_path = check_out
 
     each_category(local_path) do |category|
@@ -100,7 +100,7 @@ class Catalog
     end
   end
 
-  def each_category(path : Path)
+  def each_category(path : Path, &)
     unless File.directory?(path)
       raise Error.new "Can't read catalog at #{path}, directory does not exist."
     end

--- a/src/category.cr
+++ b/src/category.cr
@@ -10,7 +10,7 @@ class Category
     @name : String,
     @description : String? = nil,
     @entries_count : Int32 = 0,
-    @id : Int64? = nil
+    @id : Int64? = nil,
   )
   end
 end

--- a/src/db.cr
+++ b/src/db.cr
@@ -37,13 +37,13 @@ class ShardsDB
     @@db
   end
 
-  def self.connect
+  def self.connect(&)
     db.using_connection do |connection|
       yield ShardsDB.new(connection)
     end
   end
 
-  def self.transaction
+  def self.transaction(&)
     db.transaction do |transaction|
       yield ShardsDB.new(transaction.connection), transaction
     end

--- a/src/fetchers/github_api.cr
+++ b/src/fetchers/github_api.cr
@@ -46,7 +46,7 @@ struct Shardbox::GitHubAPI
     data
   end
 
-  def parse_github_graphql(content, expected_key)
+  def parse_github_graphql(content, expected_key, &)
     pull = JSON::PullParser.new(content)
 
     pull.read_object do |key|

--- a/src/release.cr
+++ b/src/release.cr
@@ -31,7 +31,7 @@ class Release
     revision_info : RevisionInfo,
     spec : Hash(String, JSON::Any) = {} of String => JSON::Any,
     yanked_at : Time? = nil,
-    latest : Bool = false
+    latest : Bool = false,
   )
     new(
       version: version,
@@ -50,7 +50,7 @@ class Release
     @spec : Hash(String, JSON::Any) = {} of String => JSON::Any,
     @yanked_at : Time? = nil,
     @latest : Bool = false,
-    @id : Int64? = nil
+    @id : Int64? = nil,
   )
   end
 

--- a/src/repo.cr
+++ b/src/repo.cr
@@ -54,7 +54,7 @@ class Repo
     @ref : Ref, @shard_id : Int64?,
     @role : Role = :canonical, @metadata = Metadata.new,
     @synced_at : Time? = nil, @sync_failed_at : Time? = nil,
-    @id : Int64? = nil
+    @id : Int64? = nil,
   )
   end
 
@@ -62,7 +62,7 @@ class Repo
     resolver : String, url : String, shard_id : Int64?,
     role : String = "canonical", metadata = Metadata.new,
     synced_at : Time? = nil, sync_failed_at : Time? = nil,
-    id : Int64? = nil
+    id : Int64? = nil,
   )
     new(Ref.new(resolver, url), shard_id, Role.parse(role), metadata, synced_at, sync_failed_at, id)
   end

--- a/src/service/create_shard.cr
+++ b/src/service/create_shard.cr
@@ -83,7 +83,7 @@ struct Service::CreateShard
   end
 
   # This method yields qualifiers for this shard in order of preference
-  private def possible_qualifiers
+  private def possible_qualifiers(&)
     # 1. No qualifier
     yield ""
 

--- a/src/service/worker_loop.cr
+++ b/src/service/worker_loop.cr
@@ -56,7 +56,7 @@ struct Service::WorkerLoop
     end
   end
 
-  def scheduled(scheduled_time : Time)
+  def scheduled(scheduled_time : Time, &)
     @running = true
 
     while running?


### PR DESCRIPTION
Crystal nightly has a couple new formatter rules enabled: https://github.com/crystal-lang/crystal/pull/14718
The changes are backwards-compatible, so Crystal 1.14.0 won't complain about the new format.